### PR TITLE
RedisBungee Fork Support

### DIFF
--- a/balancer/pom.xml
+++ b/balancer/pom.xml
@@ -67,6 +67,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>com.imaginarycode.minecraft</groupId>
+            <artifactId>RedisBungee</artifactId>
+            <version>0.6.5-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>ninja.leaping.configurate</groupId>
             <artifactId>configurate-hocon</artifactId>
             <version>3.3</version>

--- a/balancer/src/main/java/com/jaimemartz/playerbalancer/PlayerBalancer.java
+++ b/balancer/src/main/java/com/jaimemartz/playerbalancer/PlayerBalancer.java
@@ -5,6 +5,7 @@ import com.jaimemartz.playerbalancer.commands.FallbackCommand;
 import com.jaimemartz.playerbalancer.commands.MainCommand;
 import com.jaimemartz.playerbalancer.commands.ManageCommand;
 import com.jaimemartz.playerbalancer.connection.ServerAssignRegistry;
+import com.jaimemartz.playerbalancer.helper.NetworkManager;
 import com.jaimemartz.playerbalancer.helper.PasteHelper;
 import com.jaimemartz.playerbalancer.helper.PlayerLocker;
 import com.jaimemartz.playerbalancer.listeners.*;
@@ -33,6 +34,7 @@ public class PlayerBalancer extends Plugin {
     private StatusManager statusManager;
     private SettingsHolder settings;
     private SectionManager sectionManager;
+    private NetworkManager networkManager;
     private ConfigurationLoader<CommentedConfigurationNode> loader;
 
     private FallbackCommand fallbackCommand;
@@ -125,6 +127,8 @@ public class PlayerBalancer extends Plugin {
                     reloadListener = new ProxyReloadListener(this);
                     getProxy().getPluginManager().registerListener(this, reloadListener);
                 }
+
+                networkManager = new NetworkManager(this);
 
                 sectionManager = new SectionManager(this);
                 sectionManager.load();
@@ -282,5 +286,9 @@ public class PlayerBalancer extends Plugin {
 
     public FallbackCommand getFallbackCommand() {
         return fallbackCommand;
+    }
+
+    public NetworkManager getNetworkManager() {
+        return networkManager;
     }
 }

--- a/balancer/src/main/java/com/jaimemartz/playerbalancer/connection/provider/types/progressive/ProgressiveFillerProvider.java
+++ b/balancer/src/main/java/com/jaimemartz/playerbalancer/connection/provider/types/progressive/ProgressiveFillerProvider.java
@@ -17,7 +17,7 @@ public class ProgressiveFillerProvider extends AbstractProvider {
 
         for (ServerInfo server : servers) {
             ServerStatus status = plugin.getStatusManager().getStatus(server);
-            int count = server.getPlayers().size();
+            int count = plugin.getNetworkManager().getPlayers(server);
 
             if (count > max && count <= status.getMaximum()) {
                 max = count;

--- a/balancer/src/main/java/com/jaimemartz/playerbalancer/connection/provider/types/progressive/ProgressiveLowestProvider.java
+++ b/balancer/src/main/java/com/jaimemartz/playerbalancer/connection/provider/types/progressive/ProgressiveLowestProvider.java
@@ -15,7 +15,7 @@ public class ProgressiveLowestProvider extends AbstractProvider {
         ServerInfo target = null;
 
         for (ServerInfo server : servers) {
-            int count = server.getPlayers().size();
+            int count = plugin.getNetworkManager().getPlayers(server);
 
             if (count < min) {
                 min = count;

--- a/balancer/src/main/java/com/jaimemartz/playerbalancer/connection/provider/types/progressive/ProgressiveProvider.java
+++ b/balancer/src/main/java/com/jaimemartz/playerbalancer/connection/provider/types/progressive/ProgressiveProvider.java
@@ -14,7 +14,7 @@ public class ProgressiveProvider extends AbstractProvider {
     public ServerInfo requestTarget(PlayerBalancer plugin, ServerSection section, List<ServerInfo> servers, ProxiedPlayer player) {
         for (ServerInfo server : servers) {
             ServerStatus status = plugin.getStatusManager().getStatus(server);
-            if (server.getPlayers().size() < status.getMaximum()) {
+            if (plugin.getNetworkManager().getPlayers(server) < status.getMaximum()) {
                 return server;
             }
         }

--- a/balancer/src/main/java/com/jaimemartz/playerbalancer/connection/provider/types/random/RandomFillerProvider.java
+++ b/balancer/src/main/java/com/jaimemartz/playerbalancer/connection/provider/types/random/RandomFillerProvider.java
@@ -18,7 +18,7 @@ public class RandomFillerProvider extends AbstractProvider {
         int max = Integer.MIN_VALUE;
 
         for (ServerInfo server : servers) {
-            int count = server.getPlayers().size();
+            int count = plugin.getNetworkManager().getPlayers(server);
 
             if (count >= max) {
                 if (count > max) {

--- a/balancer/src/main/java/com/jaimemartz/playerbalancer/connection/provider/types/random/RandomLowestProvider.java
+++ b/balancer/src/main/java/com/jaimemartz/playerbalancer/connection/provider/types/random/RandomLowestProvider.java
@@ -18,7 +18,7 @@ public class RandomLowestProvider extends AbstractProvider {
         int min = Integer.MAX_VALUE;
 
         for (ServerInfo server : servers) {
-            int count = server.getPlayers().size();
+            int count = plugin.getNetworkManager().getPlayers(server);
 
             if (count <= min) {
                 if (count < min) {

--- a/balancer/src/main/java/com/jaimemartz/playerbalancer/helper/NetworkManager.java
+++ b/balancer/src/main/java/com/jaimemartz/playerbalancer/helper/NetworkManager.java
@@ -1,0 +1,26 @@
+package com.jaimemartz.playerbalancer.helper;
+
+import com.imaginarycode.minecraft.redisbungee.RedisBungeeAPI;
+import com.jaimemartz.playerbalancer.PlayerBalancer;
+import net.md_5.bungee.api.config.ServerInfo;
+
+public class NetworkManager {
+
+    private final PlayerBalancer plugin;
+
+    public NetworkManager(PlayerBalancer plugin) {
+        this.plugin = plugin;
+    }
+
+    public int getPlayers(ServerInfo server) {
+        if (plugin.getSettings().getGeneralProps().isRedisBungee()) {
+            try {
+                return RedisBungeeAPI.getRedisBungeeApi().getPlayersOnServer(server.getName()).size();
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+
+        return server.getPlayers().size();
+    }
+}

--- a/balancer/src/main/java/com/jaimemartz/playerbalancer/settings/props/GeneralProps.java
+++ b/balancer/src/main/java/com/jaimemartz/playerbalancer/settings/props/GeneralProps.java
@@ -19,6 +19,9 @@ public class GeneralProps {
     @Setting(value = "plugin-messaging")
     private boolean pluginMessaging;
 
+    @Setting(value = "redis-bungee")
+    private boolean redisBungee;
+
     @Setting
     private String version;
 }

--- a/balancer/src/main/resources/default.conf
+++ b/balancer/src/main/resources/default.conf
@@ -11,6 +11,9 @@ general {
   # When true, the plugin will reload when you execute /greload
   auto-reload=true
 
+  # When true, the plugin will get player counts from RedisBungee (Limework Fork: https://www.spigotmc.org/resources/87700/)
+  redis-bungee=false
+
   # When true, this plugin will print less messages when loading
   silent=false
 


### PR DESCRIPTION
As there is now an updated version of RedisBungee being created by [Limework](https://github.com/Limework/RedisBungee)/@ham1255 I went ahead and re-added support for RedisBungee. I was planning on just using this myself but wanted to give it to the community if they wish to use it as well. 

The only change from the old RedisBungee code was not using the deprecated `RedisBungee.getApi()` and rather using `RedisBungeeAPI.getRedisBungeeApi()`. I also used the new Maven repo for the updated fork. 

I am planning to make a few more PR's as I come across stuff I want to add in the next few weeks.

@jamezrin Happy to take over maintaining PlayerBalancer if you wish, really a passion project for me to work on at points :)